### PR TITLE
support for 'REQUEST' authorizer type

### DIFF
--- a/library/apigw_authorizer.py
+++ b/library/apigw_authorizer.py
@@ -55,7 +55,7 @@ options:
     description:
     - Type of the authorizer (required when C(state) is 'present')
     required: False
-    choices: ['TOKEN', 'COGNITO_USER_POOLS']
+    choices: ['TOKEN', 'REQUEST', 'COGNITO_USER_POOLS']
     default: None
   uri:
     description:
@@ -181,7 +181,7 @@ class ApiGwAuthorizer:
     """
     return dict( rest_api_id=dict(required=True),
                  name=dict(required=True),
-                 type=dict(required=False, choices=['TOKEN', 'COGNITO_USER_POOLS']),
+                 type=dict(required=False, choices=['TOKEN', 'REQUEST', 'COGNITO_USER_POOLS']),
                  uri=dict(required=False),
                  identity_source=dict(required=False),
                  identity_validation_expression=dict(required=False, default=''),

--- a/tests/test_apigw_authorizer.py
+++ b/tests/test_apigw_authorizer.py
@@ -344,7 +344,7 @@ class TestApiGwAuthorizer(unittest.TestCase):
     self.assertEqual(result, dict(
                      rest_api_id=dict(required=True),
                      name=dict(required=True),
-                     type=dict(required=False, choices=['TOKEN', 'COGNITO_USER_POOLS']),
+                     type=dict(required=False, choices=['TOKEN', 'REQUEST', 'COGNITO_USER_POOLS']),
                      uri=dict(required=False),
                      identity_source=dict(required=False),
                      identity_validation_expression=dict(required=False, default=''),


### PR DESCRIPTION
support ["request" authorizer type](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/apigateway.html#APIGateway.Client.create_authorizer)